### PR TITLE
Make canvas responsive

### DIFF
--- a/src/components/CharacterPreview/CharacterPreview.tsx
+++ b/src/components/CharacterPreview/CharacterPreview.tsx
@@ -65,61 +65,63 @@ export default function CharacterPreview({ character, colors }: Props) {
     isDownloading || status === "error" || status === "loading";
 
   return (
-    <section className="flex h-full flex-grow flex-col flex-nowrap justify-center py-8">
-      <div ref={containerRef} className="w-full flex-grow py-4">
+    <section className="flex h-full flex-grow flex-col flex-nowrap justify-center gap-y-4 py-10">
+      <div ref={containerRef} className="w-full flex-shrink flex-grow py-4">
         {/*
          * Reminder: You cannot set any CSS properties on a canvas that would
          * change its size. You have to update the HTML directly (doing the
-         * math for it), or else the canvas output will distort
+         * math for it), or else the canvas output will become distorted
          */}
         <canvas ref={canvasRef} className="mx-auto">
           A preview of a {character.class} from {character.game}
         </canvas>
       </div>
 
-      <fieldset className="mx-auto flex max-w-fit flex-row flex-nowrap items-center gap-x-4 pt-6">
-        <legend>
-          <VisuallyHidden.Root>Main app button controls</VisuallyHidden.Root>
-        </legend>
+      <div>
+        <fieldset className="mx-auto flex max-w-fit flex-row flex-nowrap items-center gap-x-4">
+          <legend>
+            <VisuallyHidden.Root>Main app button controls</VisuallyHidden.Root>
+          </legend>
 
-        <GuideButton
-          buttonText="Help"
-          modalTitle="Help"
-          modalDescription="How to use this application"
-        >
-          Baba-booey Baba-booey
-        </GuideButton>
+          <GuideButton
+            buttonText="Help"
+            modalTitle="Help"
+            modalDescription="How to use this application"
+          >
+            Baba-booey Baba-booey
+          </GuideButton>
 
-        <button
-          type="button"
-          className="select-none rounded-full bg-teal-800 px-7 py-3 text-xl font-medium text-teal-50 shadow-md transition-colors"
-          disabled={downloadsDisabled}
-          onClick={downloadAllImages}
-        >
-          Download
-        </button>
+          <button
+            type="button"
+            className="select-none rounded-full bg-teal-800 px-7 py-3 text-xl font-medium text-teal-50 shadow-md transition-colors"
+            disabled={downloadsDisabled}
+            onClick={downloadAllImages}
+          >
+            Download
+          </button>
 
-        <GuideButton
-          buttonText="Credits"
-          modalTitle="Credits"
-          modalDescription="Credits and colophon"
-        >
-          Baba-booey Baba-booey
-        </GuideButton>
-      </fieldset>
+          <GuideButton
+            buttonText="Credits"
+            modalTitle="Credits"
+            modalDescription="Credits and colophon"
+          >
+            Baba-booey Baba-booey
+          </GuideButton>
+        </fieldset>
 
-      <p className="mx-auto mt-4 w-fit rounded-full bg-yellow-100 px-4 py-2 text-center text-sm font-medium text-yellow-900">
-        Work in progress.{" "}
-        <a
-          className="underline"
-          href="https://github.com/Parkreiner/etrian-character-customizer"
-          target="_blank"
-          rel="noreferrer"
-        >
-          Check the GitHub page
-        </a>{" "}
-        for updates.
-      </p>
+        <p className="mx-auto mt-4 w-fit rounded-full bg-yellow-100 px-4 py-2 text-center text-sm font-medium text-yellow-900">
+          Work in progress.{" "}
+          <a
+            className="underline"
+            href="https://github.com/Parkreiner/etrian-character-customizer"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Check the GitHub page
+          </a>{" "}
+          for updates.
+        </p>
+      </div>
     </section>
   );
 }

--- a/src/components/CharacterPreview/CharacterPreview.tsx
+++ b/src/components/CharacterPreview/CharacterPreview.tsx
@@ -1,18 +1,14 @@
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 
 import { Character } from "@/typesConstants/gameData";
 import { CharacterColors } from "@/typesConstants/colors";
-import {
-  CANVAS_WIDTH,
-  CANVAS_HEIGHT,
-  renderCharacter,
-  imageToDataUrl,
-} from "./canvasHelpers";
+import { imageToDataUrl } from "./canvasHelpers";
 
 import GuideButton from "./GuideButton";
 import useLazyImageLoading from "@/hooks/useLazyImageLoading";
 import { handleError } from "@/utils/errors";
+import usePreview from "./usePreview";
 
 type Props = {
   character: Character;
@@ -30,19 +26,7 @@ function downloadCharacter(filename: string, dataUrl: string): void {
 export default function CharacterPreview({ character, colors }: Props) {
   const [isDownloading, setIsDownloading] = useState(false);
   const { bitmap, status, loadImage } = useLazyImageLoading(character.imgUrl);
-  const previewCanvasRef = useRef<HTMLCanvasElement>(null);
-
-  useLayoutEffect(() => {
-    const previewContext = previewCanvasRef.current?.getContext("2d") ?? null;
-    if (previewContext === null || bitmap === null) return;
-
-    renderCharacter(previewContext, bitmap, colors, character);
-
-    return () => {
-      previewContext.fillStyle = "#000000";
-      previewContext.clearRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
-    };
-  }, [bitmap, colors, character]);
+  const { containerRef, canvasRef } = usePreview(bitmap, colors, character);
 
   useEffect(() => {
     if (bitmap !== null) return;
@@ -54,7 +38,8 @@ export default function CharacterPreview({ character, colors }: Props) {
   // images are being hosted on a separate source (Imgur). Browsers will treat
   // the canvas as "tainted" until the image comes from a same-source server
   const downloadAllImages = async () => {
-    if (bitmap === null) return;
+    const canvas = canvasRef.current;
+    if (bitmap === null || canvas === null) return;
     setIsDownloading(true);
 
     // This looks hokey, but it ensures that the first state update finishes
@@ -80,15 +65,17 @@ export default function CharacterPreview({ character, colors }: Props) {
     isDownloading || status === "error" || status === "loading";
 
   return (
-    <section className="flex h-full flex-grow flex-col flex-nowrap justify-center pt-6">
-      <canvas
-        ref={previewCanvasRef}
-        className="mx-auto w-[450px] grow-0 border-2 border-teal-700"
-        width={CANVAS_WIDTH}
-        height={CANVAS_HEIGHT}
-      >
-        A preview of a {character.class} from {character.game}
-      </canvas>
+    <section className="flex h-full flex-grow flex-col flex-nowrap justify-center py-8">
+      <div ref={containerRef} className="w-full flex-grow py-4">
+        {/*
+         * Reminder: You cannot set any CSS properties on a canvas that would
+         * change its size. You have to update the HTML directly (doing the
+         * math for it), or else the canvas output will distort
+         */}
+        <canvas ref={canvasRef} className="mx-auto">
+          A preview of a {character.class} from {character.game}
+        </canvas>
+      </div>
 
       <fieldset className="mx-auto flex max-w-fit flex-row flex-nowrap items-center gap-x-4 pt-6">
         <legend>

--- a/src/components/CharacterPreview/canvasHelpers.ts
+++ b/src/components/CharacterPreview/canvasHelpers.ts
@@ -2,15 +2,30 @@ import { Character } from "@/typesConstants/gameData";
 import { CharacterColors } from "@/typesConstants/colors";
 
 const PLACEHOLDER_FILL = "#ff00ff";
-export const CANVAS_WIDTH = 600;
-export const CANVAS_HEIGHT = 960;
+
+export function getCanvasContext(
+  canvas: HTMLCanvasElement
+): CanvasRenderingContext2D {
+  const context = canvas.getContext("2d");
+  if (context === null) {
+    throw new Error(
+      "Rendering context is null. This should only be possible if you accidentally set up multiple contexts for the same canvas"
+    );
+  }
+
+  return context;
+}
 
 export function renderCharacter(
-  canvasContext: CanvasRenderingContext2D,
+  canvas: HTMLCanvasElement,
   charBitmap: ImageBitmap,
   colors: CharacterColors,
   character: Character
 ): void {
+  const canvasContext = getCanvasContext(canvas);
+  const width = canvas.width;
+  const height = canvas.height;
+
   const sortedPaths = [...character.paths].sort((entry1, entry2) => {
     return entry1.layerIndex - entry2.layerIndex;
   });
@@ -23,8 +38,7 @@ export function renderCharacter(
     canvasContext.fill(pathNode);
   }
 
-  const height = CANVAS_WIDTH * (charBitmap.height / charBitmap.width);
-  canvasContext.drawImage(charBitmap, 0, 0, CANVAS_WIDTH, height);
+  canvasContext.drawImage(charBitmap, 0, 0, width, height);
 }
 
 export function imageToDataUrl(
@@ -36,13 +50,6 @@ export function imageToDataUrl(
   outputCanvas.width = charBitmap.width;
   outputCanvas.height = charBitmap.height;
 
-  const outputContext = outputCanvas.getContext("2d");
-  if (outputContext === null) {
-    throw new Error(
-      "outputCanvas declared with multiple rendering contexts - this should be physically impossible"
-    );
-  }
-
-  renderCharacter(outputContext, charBitmap, colors, character);
+  renderCharacter(outputCanvas, charBitmap, colors, character);
   return outputCanvas.toDataURL();
 }

--- a/src/components/CharacterPreview/usePreview.ts
+++ b/src/components/CharacterPreview/usePreview.ts
@@ -1,0 +1,99 @@
+import { useLayoutEffect, useRef, useState } from "react";
+
+import { getCanvasContext, renderCharacter } from "./canvasHelpers";
+import { CharacterColors } from "@/typesConstants/colors";
+import { Character } from "@/typesConstants/gameData";
+
+/**
+ * Alternative ideas if the double-rendering from useState becomes an issue:
+ * - Remove the two useStates and the previous useLayoutEffect, in favor of
+ *   making this run with no dependency array. If I handle the conditional
+ *   logic in the effect, I think that could potentially avoid the double-
+ *   render issues. No dependency array feels weird, though
+ *
+ *   The effect would just read the values from the container directly and
+ *   resize the canvas to match. Not sure if that would mean I would have to
+ *   combine the rendering effect here as well
+ */
+export default function usePreview(
+  bitmap: ImageBitmap | null,
+  colors: CharacterColors,
+  character: Character
+) {
+  // Have to initialize as null because dimensions won't exist until after first
+  // mount. Storing values separately to make effect dependencies easier
+  const [availableWidth, setAvailableWidth] = useState<number | null>(null);
+  const [availableHeight, setAvailableHeight] = useState<number | null>(null);
+
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Subscribe React to any changes in the container's dimensions
+  useLayoutEffect(() => {
+    if (containerRef.current === null) return;
+
+    const observer = new ResizeObserver((observedEntries) => {
+      const sizeInfo = observedEntries[0]?.contentBoxSize[0];
+      const canvas = canvasRef.current;
+
+      if (sizeInfo === undefined || canvas === null) return;
+      setAvailableWidth(sizeInfo.inlineSize);
+      setAvailableHeight(sizeInfo.blockSize);
+    });
+
+    observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, []);
+
+  // Resize the canvas dimensions based on container and bitmap size. Cannot
+  // use ANY sizing CSS on canvas whatsoever, or else the output distorts
+  useLayoutEffect(() => {
+    const canvas = canvasRef.current;
+    const ready =
+      canvas !== null &&
+      bitmap !== null &&
+      availableWidth !== null &&
+      availableHeight !== null;
+
+    if (!ready) return;
+
+    let width: number;
+    let height: number;
+    if (bitmap.height >= bitmap.width) {
+      const aspectConversionRatio = bitmap.width / bitmap.height;
+      height = Math.min(availableHeight, bitmap.height);
+      width = height * aspectConversionRatio;
+    } else {
+      const aspectConversionRatio = bitmap.height / bitmap.width;
+      width = Math.min(availableWidth, bitmap.width);
+      height = width * aspectConversionRatio;
+    }
+
+    canvas.width = width;
+    canvas.height = height;
+  }, [bitmap, availableWidth, availableHeight]);
+
+  // Renders character to the canvas when image input changes
+  useLayoutEffect(() => {
+    const canvas = canvasRef.current;
+    if (canvas === null) return;
+
+    const canRender =
+      canvas !== null &&
+      bitmap !== null &&
+      availableWidth !== null &&
+      availableHeight !== null;
+
+    if (!canRender) return;
+
+    const previewContext = getCanvasContext(canvas);
+    renderCharacter(canvas, bitmap, colors, character);
+
+    return () => {
+      previewContext.fillStyle = "#000000";
+      previewContext.clearRect(0, 0, canvas.width, canvas.height);
+    };
+  }, [bitmap, character, colors, availableWidth, availableHeight]);
+
+  return { containerRef, canvasRef } as const;
+}

--- a/src/components/Editor/editorStateMocks.ts
+++ b/src/components/Editor/editorStateMocks.ts
@@ -206,9 +206,9 @@ const characters: readonly Omit<Character, "id">[] = [
   },
 
   {
-    game: "eo1",
+    game: "eo2",
     class: "guest",
-    displayId: "3",
+    displayId: "1",
     imgUrl: "https://i.imgur.com/H9DdfNY.png",
     paths: [...basePathMocks, misc1, misc2],
 
@@ -300,9 +300,9 @@ const characters: readonly Omit<Character, "id">[] = [
     },
   },
   {
-    game: "eo1",
+    game: "eo3",
     class: "guest",
-    displayId: "4",
+    displayId: "2",
     imgUrl: "https://i.imgur.com/1MkXJFr.png",
     paths: [...basePathMocks, misc1, misc2],
     totalColors: 11,

--- a/src/components/Editor/editorStateMocks.ts
+++ b/src/components/Editor/editorStateMocks.ts
@@ -78,11 +78,12 @@ const misc3: CanvasPathEntry = {
 };
 
 const characters: readonly Omit<Character, "id">[] = [
+  // EO1 Protector 1
   {
     game: "eo1",
     class: "protector",
     displayId: "1",
-    imgUrl: "https://i.imgur.com/gUP2q9Z.png",
+    imgUrl: "https://i.imgur.com/7I1k2X2.png",
     paths: basePathMocks,
     totalColors: 8,
 
@@ -99,11 +100,13 @@ const characters: readonly Omit<Character, "id">[] = [
       misc: [],
     },
   },
+
+  // EO1 Teach
   {
     game: "eo1",
     class: "protector",
     displayId: "2",
-    imgUrl: "https://i.imgur.com/kFRBqKf.png",
+    imgUrl: "https://i.imgur.com/xfqdPUn.png",
     paths: basePathMocks,
     totalColors: 8,
 
@@ -120,11 +123,13 @@ const characters: readonly Omit<Character, "id">[] = [
       misc: [],
     },
   },
+
+  // EO1 protector 3
   {
     game: "eo1",
     class: "protector",
     displayId: "3",
-    imgUrl: "https://i.imgur.com/JgiPmIr.png",
+    imgUrl: "https://i.imgur.com/8AAoLIK.png",
     paths: basePathMocks,
     totalColors: 8,
 
@@ -141,11 +146,13 @@ const characters: readonly Omit<Character, "id">[] = [
       misc: [],
     },
   },
+
+  // EO1 protector 4
   {
     game: "eo1",
     class: "protector",
     displayId: "4",
-    imgUrl: "https://i.imgur.com/g4uNxbA.png",
+    imgUrl: "https://i.imgur.com/eAA3iZP.png",
     paths: basePathMocks,
     totalColors: 8,
 
@@ -162,11 +169,13 @@ const characters: readonly Omit<Character, "id">[] = [
       misc: [],
     },
   },
+
+  // New protector (EO1 version)
   {
     game: "eo1",
     class: "protector",
     displayId: "5",
-    imgUrl: "https://i.imgur.com/2eiuAIn.png",
+    imgUrl: "https://i.imgur.com/nkNMx5E.png",
     paths: basePathMocks,
     totalColors: 8,
 
@@ -183,11 +192,13 @@ const characters: readonly Omit<Character, "id">[] = [
       misc: [],
     },
   },
+
+  // New medic (EO1 version)
   {
     game: "eo1",
     class: "medic",
     displayId: "5",
-    imgUrl: "https://i.imgur.com/20qTHXw.png",
+    imgUrl: "https://i.imgur.com/K4Y78kh.png",
     paths: basePathMocks,
     totalColors: 8,
 
@@ -205,15 +216,16 @@ const characters: readonly Omit<Character, "id">[] = [
     },
   },
 
+  // Demi-Fiend (EO2)
   {
     game: "eo2",
     class: "guest",
     displayId: "1",
-    imgUrl: "https://i.imgur.com/H9DdfNY.png",
+    imgUrl: "https://i.imgur.com/5jTaytn.png",
     paths: [...basePathMocks, misc1, misc2],
 
     // The Demi-Fiend actually has only 1 color per eye, so the total is
-    // supposed should be 8, not 10. First example of why I need to update the
+    // supposed to be 8, not 10. First example of why I need to update the
     // colors to be arrays and not fixed-length tuples
     totalColors: 8,
 
@@ -230,11 +242,13 @@ const characters: readonly Omit<Character, "id">[] = [
       misc: ["#32353c", "#c7fff3"],
     },
   },
+
+  // New Gunner
   {
     game: "eo2",
     class: "gunner",
     displayId: "5",
-    imgUrl: "https://i.imgur.com/Kuhvorj.png",
+    imgUrl: "https://i.imgur.com/mW4fl9G.png",
     paths: [...basePathMocks, misc1, misc2],
 
     // Gunner also only has one eye color - at least, as far as I can tell with
@@ -254,11 +268,13 @@ const characters: readonly Omit<Character, "id">[] = [
       misc: ["#392f3c", "#781d29"],
     },
   },
+
+  // Joker (EO1)
   {
     game: "eo1",
     class: "guest",
     displayId: "1",
-    imgUrl: "https://i.imgur.com/7K56GfS.png",
+    imgUrl: "https://i.imgur.com/bWSsXTM.png",
     paths: [...basePathMocks, misc1],
     totalColors: 9,
 
@@ -275,11 +291,13 @@ const characters: readonly Omit<Character, "id">[] = [
       misc: ["#810c0d"],
     },
   },
+
+  // Ringo (EO1)
   {
     game: "eo1",
     class: "guest",
     displayId: "2",
-    imgUrl: "https://i.imgur.com/ZJP7e1r.png",
+    imgUrl: "https://i.imgur.com/NVSUUHt.png",
     paths: [...basePathMocks, misc1, misc2, misc3],
     totalColors: 11,
 
@@ -299,11 +317,13 @@ const characters: readonly Omit<Character, "id">[] = [
       misc: ["#ffff00", "#7bdb18", "#088c91"],
     },
   },
+
+  // Aigis (EO3)
   {
     game: "eo3",
     class: "guest",
     displayId: "2",
-    imgUrl: "https://i.imgur.com/1MkXJFr.png",
+    imgUrl: "https://i.imgur.com/M57BmSu.png",
     paths: [...basePathMocks, misc1, misc2],
     totalColors: 11,
 


### PR DESCRIPTION
Minor feature, but very necessary for making the app work predictably. This adds logic for making sure that the HTML canvas is able to respond to changes in character bitmaps, as well as the available space – all without causing the canvas output to distort.

Also, while getting this set up, I got some basic Vercel auto-deployment stuff in place.