### PR TITLE
fix: Resolve Firefox-specific styling issues

### DIFF
--- a/src/components/CharacterMenus/CharacterMenus.tsx
+++ b/src/components/CharacterMenus/CharacterMenus.tsx
@@ -77,7 +77,7 @@ export default function CharacterMenus({
   );
 
   return (
-    <section className="flex h-full w-[430px] flex-col flex-nowrap bg-teal-600 pb-1.5">
+    <section className="flex h-full w-[430px] shrink-0 flex-col flex-nowrap bg-teal-600 pb-1.5">
       <section className="flex flex-nowrap items-baseline justify-between bg-teal-100 py-3 pl-7 pr-5">
         <HeaderTag className="text-base font-medium italic text-teal-950">
           Etrian Character Customizer

--- a/src/components/ColorPicker/ChannelInput.tsx
+++ b/src/components/ColorPicker/ChannelInput.tsx
@@ -43,7 +43,8 @@ export default function ChannelInput({
 
       <div className="flex grow flex-row flex-nowrap items-center justify-center px-1">
         <input
-          className="no-arrow grow bg-inherit text-center font-medium"
+          // Max width in place to prevent Firefox-specific styling issues
+          className="no-arrow max-w-[50px] grow bg-inherit text-center font-medium"
           type="number"
           id={numberInputId}
           value={value}

--- a/src/components/ColorPicker/HueWheel.tsx
+++ b/src/components/ColorPicker/HueWheel.tsx
@@ -25,7 +25,7 @@ export default function ColorHueWheel({ hue, onHueChange }: Props) {
         Hue
       </label>
 
-      <div className="flex -translate-y-0.5 align-top text-[48px] leading-none">
+      <div className="flex -translate-y-0.5 align-top leading-none">
         {/* Min/max are a little funky to make hue wrap-arounds easier */}
         <input
           id={textId}
@@ -37,7 +37,7 @@ export default function ColorHueWheel({ hue, onHueChange }: Props) {
           value={hue}
           onChange={(e) => onHueChange(wrapHue(e.target.valueAsNumber))}
         />
-        <span className="h-fit select-none font-medium">°</span>
+        <span className="h-fit select-none text-[48px] font-medium">°</span>
       </div>
 
       <button

--- a/src/components/ColorPicker/HueWheel.tsx
+++ b/src/components/ColorPicker/HueWheel.tsx
@@ -29,13 +29,15 @@ export default function ColorHueWheel({ hue, onHueChange }: Props) {
         {/* Min/max are a little funky to make hue wrap-arounds easier */}
         <input
           id={textId}
-          className="no-arrow h-16 bg-teal-900 text-right text-[64px] font-bold"
           type="number"
           min="-1"
           max="360"
           step="1"
           value={hue}
           onChange={(e) => onHueChange(wrapHue(e.target.valueAsNumber))}
+          // All the extra width properties are meant to help with a Firefox-
+          // specific sizing issue when tring to style text inputs
+          className="no-arrow block h-16 w-fit min-w-0 max-w-[170px] bg-teal-900 text-right text-[64px] font-bold"
         />
         <span className="h-fit select-none text-[48px] font-medium">°</span>
       </div>


### PR DESCRIPTION
Much better.
<img width="1711" alt="Screen Shot 2023-06-04 at 11 17 45 PM" src="https://github.com/Parkreiner/etrian-character-customizer/assets/28937484/a1cd6142-7e53-4955-8039-9e964253755e">
