### PR TITLE
Redesign modals

### DIFF
--- a/src/components/CharacterPreview/CharacterPreview.tsx
+++ b/src/components/CharacterPreview/CharacterPreview.tsx
@@ -5,10 +5,11 @@ import { Character } from "@/typesConstants/gameData";
 import { CharacterColors } from "@/typesConstants/colors";
 import { imageToDataUrl } from "./canvasHelpers";
 
-import GuideButton from "./GuideButton";
-import useLazyImageLoading from "@/hooks/useLazyImageLoading";
 import { handleError } from "@/utils/errors";
+import useLazyImageLoading from "@/hooks/useLazyImageLoading";
 import usePreview from "./usePreview";
+import CreditsButton from "./CreditsButton";
+import HelpButton from "./HelpButton";
 
 type Props = {
   character: Character;
@@ -83,13 +84,7 @@ export default function CharacterPreview({ character, colors }: Props) {
             <VisuallyHidden.Root>Main app button controls</VisuallyHidden.Root>
           </legend>
 
-          <GuideButton
-            buttonText="Help"
-            modalTitle="Help"
-            modalDescription="How to use this application"
-          >
-            Baba-booey Baba-booey
-          </GuideButton>
+          <HelpButton />
 
           <button
             type="button"
@@ -100,13 +95,7 @@ export default function CharacterPreview({ character, colors }: Props) {
             Download
           </button>
 
-          <GuideButton
-            buttonText="Credits"
-            modalTitle="Credits"
-            modalDescription="Credits and colophon"
-          >
-            Baba-booey Baba-booey
-          </GuideButton>
+          <CreditsButton />
         </fieldset>
 
         <p className="mx-auto mt-4 w-fit rounded-full bg-yellow-100 px-4 py-2 text-center text-sm font-medium text-yellow-900">

--- a/src/components/CharacterPreview/CreditsButton.tsx
+++ b/src/components/CharacterPreview/CreditsButton.tsx
@@ -5,28 +5,60 @@ export default function CreditsButton() {
     <Modal
       buttonText="Credits"
       modalTitle="Credits"
-      modalDescription="Special thanks and colophon"
+      modalDescription="Special thanks and misc. notes"
     >
-      <Modal.Subheader>Special Thanks</Modal.Subheader>
+      <Modal.Subsection title="Special thanks">
+        <Modal.List>
+          <Modal.ListItem>
+            Big thanks to Josh Comeau&apos;s Discord community for his learning
+            platform (particularly{" "}
+            <Modal.Link href="https://www.joshwcomeau.com/">
+              Josh himself
+            </Modal.Link>{" "}
+            and{" "}
+            <Modal.Link href="https://bonnie.dev/">Bonnie Schulkin</Modal.Link>
+            ), for helping me really solidify my mental models for React and
+            CSS, and being so willing to help out with any bugs I ran into.
+          </Modal.ListItem>
 
-      <Modal.List>
-        <Modal.ListItem>b</Modal.ListItem>
-      </Modal.List>
+          <Modal.ListItem>
+            Also incredibly grateful to the Etrian Oddyssey Data Mining and
+            Coding community on Discord (private community) for humoring all my
+            weird, annoying Unity asset quesions.
+          </Modal.ListItem>
+        </Modal.List>
+      </Modal.Subsection>
 
-      <Modal.Subheader>Typesetting info</Modal.Subheader>
+      <Modal.Subsection title="Colophon">
+        <Modal.Paragraph>
+          Typeset in{" "}
+          <Modal.Link href="https://fonts.google.com/specimen/Proza+Libre">
+            Proza Libre (free via Google Fonts)
+          </Modal.Link>{" "}
+          and{" "}
+          <Modal.Link href="https://bureauroffa.com/about-prozadisplay">
+            Proza Display (licensed)
+          </Modal.Link>
+          , both designed by{" "}
+          <Modal.Link href="https://bureauroffa.com/">Bureau Roffa</Modal.Link>.
+        </Modal.Paragraph>
+      </Modal.Subsection>
 
-      <Modal.Paragraph italicized>
-        Set with{" "}
-        <Modal.Link href="https://fonts.google.com/specimen/Proza+Libre">
-          Proza Libre
-        </Modal.Link>{" "}
-        and{" "}
-        <Modal.Link href="https://bureauroffa.com/about-prozadisplay">
-          Proza Display
-        </Modal.Link>
-        , both designed by{" "}
-        <Modal.Link href="https://bureauroffa.com/">Bureau Roffa</Modal.Link>.
-      </Modal.Paragraph>
+      <Modal.Subsection title="Other links">
+        <Modal.List>
+          <Modal.ListItem>
+            <Modal.Link href="https://github.com/Parkreiner">
+              My GitHub
+            </Modal.Link>
+          </Modal.ListItem>
+
+          <Modal.ListItem>
+            <Modal.Link href="https://www.linkedin.com/in/michael-eric-smith/">
+              My LinkedIn
+            </Modal.Link>
+          </Modal.ListItem>
+        </Modal.List>
+      </Modal.Subsection>
     </Modal>
   );
 }

--- a/src/components/CharacterPreview/CreditsButton.tsx
+++ b/src/components/CharacterPreview/CreditsButton.tsx
@@ -1,0 +1,32 @@
+import Modal from "../Modal";
+
+export default function CreditsButton() {
+  return (
+    <Modal
+      buttonText="Credits"
+      modalTitle="Credits"
+      modalDescription="Special thanks and colophon"
+    >
+      <Modal.Subheader>Special Thanks</Modal.Subheader>
+
+      <Modal.List>
+        <Modal.ListItem>b</Modal.ListItem>
+      </Modal.List>
+
+      <Modal.Subheader>Typesetting info</Modal.Subheader>
+
+      <Modal.Paragraph italicized>
+        Set with{" "}
+        <Modal.Link href="https://fonts.google.com/specimen/Proza+Libre">
+          Proza Libre
+        </Modal.Link>{" "}
+        and{" "}
+        <Modal.Link href="https://bureauroffa.com/about-prozadisplay">
+          Proza Display
+        </Modal.Link>
+        , both designed by{" "}
+        <Modal.Link href="https://bureauroffa.com/">Bureau Roffa</Modal.Link>.
+      </Modal.Paragraph>
+    </Modal>
+  );
+}

--- a/src/components/CharacterPreview/GuideButton.tsx
+++ b/src/components/CharacterPreview/GuideButton.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from "react";
+import { PropsWithChildren, useLayoutEffect, useRef } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 
 type Props = PropsWithChildren<{
@@ -7,12 +7,107 @@ type Props = PropsWithChildren<{
   modalDescription: string;
 }>;
 
-export default function GuideButton({
+function useModalBackground() {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const backgroundRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const content = contentRef.current;
+    if (content === null) return;
+
+    const syncBgWithContent: ResizeObserverCallback = (observedEntries) => {
+      const content = contentRef.current;
+      const background = backgroundRef.current;
+      if (content === null || background === null) return;
+
+      const sizeInfo = observedEntries[0]?.borderBoxSize[0];
+      if (sizeInfo === undefined) return;
+
+      const containerWidth = sizeInfo.inlineSize;
+      const viewportWidth = window.innerWidth;
+      const height = window.innerHeight;
+
+      const heightSq = height ** 2;
+      const bgWidth = Math.round(Math.sqrt(containerWidth ** 2 + heightSq));
+      const bgHeight = Math.round(Math.sqrt(viewportWidth ** 2 + heightSq));
+
+      // Need to figure out actual formula
+      const bgRotation = -35;
+
+      background.style.width = `${bgWidth}px`;
+      background.style.height = `${bgHeight}px`;
+      background.style.transform = `rotate(${bgRotation}deg)`;
+    };
+
+    const observer = new ResizeObserver(syncBgWithContent);
+    observer.observe(content);
+    return () => observer.disconnect();
+  }, []);
+
+  return { contentRef, backgroundRef } as const;
+}
+
+/**
+ * Have to split the content up as a separate component, because the mounting
+ * hooks need to run fresh every single time Radix conditionally renders this
+ * to the portal.
+ *
+ * The effect hook only ever runs once on mount, but if it were called in the
+ * parent, it would be called for HTML elements that the parent wouldn't be
+ * rendering yet. And so, there would be no ref values for the effect to read
+ */
+function CoreContent({
   children,
-  buttonText,
   modalTitle,
   modalDescription,
-}: Props) {
+}: Omit<Props, "buttonText">) {
+  const { contentRef, backgroundRef } = useModalBackground();
+
+  return (
+    <div className="fixed left-0 top-0 flex h-full w-full flex-col items-center justify-center text-teal-50">
+      <div ref={backgroundRef} className="fixed z-10 bg-teal-950" />
+
+      <Dialog.Content
+        ref={contentRef}
+        className="z-20 h-full w-full max-w-prose overflow-y-auto bg-teal-950 p-10 shadow-md"
+      >
+        <Dialog.Title className="mb-1 text-4xl font-extralight italic opacity-80">
+          {modalTitle}
+        </Dialog.Title>
+
+        <Dialog.Description className="mb-4 pb-1 italic opacity-80">
+          {modalDescription}
+        </Dialog.Description>
+
+        <div className="overflow-y-auto">{children}</div>
+
+        <Dialog.Close asChild>
+          <button
+            className="absolute right-12 top-10 block rounded-full border-2 border-teal-100 bg-teal-900 p-4 outline outline-4 outline-teal-900"
+            aria-label="Close modal"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="rgb(204 251 241)"
+              className="h-6 w-6"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </Dialog.Close>
+      </Dialog.Content>
+    </div>
+  );
+}
+
+export default function GuideButton({ buttonText, ...delegated }: Props) {
   return (
     <Dialog.Root>
       <Dialog.Trigger asChild>
@@ -22,42 +117,8 @@ export default function GuideButton({
       </Dialog.Trigger>
 
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed left-0 top-0 h-full w-full backdrop-blur-sm" />
-
-        <div className="fixed left-0 top-0 flex h-full w-full items-center justify-center">
-          <Dialog.Content className="relative min-h-[400px] w-full max-w-prose rounded-md bg-white p-10 shadow-md">
-            <Dialog.Title className="text-2xl font-bold">
-              {modalTitle}
-            </Dialog.Title>
-
-            <Dialog.Description className="mb-4 border-b-2 border-black pb-1 italic opacity-80">
-              {modalDescription}
-            </Dialog.Description>
-
-            <div>{children}</div>
-
-            <Dialog.Close
-              className="absolute right-10 top-10"
-              type="button"
-              aria-label="Close modal"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                strokeWidth={1.5}
-                stroke="currentColor"
-                className="h-6 w-6"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M6 18L18 6M6 6l12 12"
-                />
-              </svg>
-            </Dialog.Close>
-          </Dialog.Content>
-        </div>
+        <Dialog.Overlay className="fixed left-0 top-0 h-full w-full backdrop-blur-md" />
+        <CoreContent {...delegated} />
       </Dialog.Portal>
     </Dialog.Root>
   );

--- a/src/components/CharacterPreview/HelpButton.tsx
+++ b/src/components/CharacterPreview/HelpButton.tsx
@@ -7,7 +7,7 @@ export default function HelpButton() {
       modalTitle="Help"
       modalDescription="How to use this application"
     >
-      Baba-booey Baba-booey
+      Instructions coming soon!
     </Modal>
   );
 }

--- a/src/components/CharacterPreview/HelpButton.tsx
+++ b/src/components/CharacterPreview/HelpButton.tsx
@@ -1,0 +1,13 @@
+import Modal from "../Modal";
+
+export default function HelpButton() {
+  return (
+    <Modal
+      buttonText="Help"
+      modalTitle="Help"
+      modalDescription="How to use this application"
+    >
+      Baba-booey Baba-booey
+    </Modal>
+  );
+}

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -46,10 +46,10 @@ type CoreProps = Omit<ModalProps, "buttonText">;
  * restructure the HTML without losing all the necessary containers for my
  * needlessly fancy styling
  */
-const CoreContent = forwardRef<
-  HTMLHeadingElement | HTMLParagraphElement,
-  CoreProps
->(function CoreContent({ children, modalTitle, modalDescription }, radixRef) {
+const CoreContent = forwardRef(function CoreContent(
+  { children, modalTitle, modalDescription }: CoreProps,
+  radixRef?: React.ForwardedRef<HTMLHeadingElement | HTMLParagraphElement>
+) {
   const { contentRef, topBgRef, bottomBgRef } = useModalBackground();
 
   return (
@@ -85,7 +85,7 @@ const CoreContent = forwardRef<
 
           <Dialog.Close asChild>
             <button
-              className="block flex-shrink-0 self-start rounded-full border-2 border-teal-100 bg-teal-900 p-4 outline outline-4 outline-teal-900 lg:absolute lg:right-12 lg:top-10"
+              className="block flex-shrink-0 self-start rounded-full border-2 border-teal-100 bg-teal-900 stroke-teal-100 p-4 outline outline-4 outline-teal-900 transition-colors duration-150 hover:bg-teal-800 hover:outline-teal-800 lg:absolute lg:right-12 lg:top-10"
               aria-label="Close modal"
             >
               <svg
@@ -93,7 +93,6 @@ const CoreContent = forwardRef<
                 fill="none"
                 viewBox="0 0 24 24"
                 strokeWidth={2}
-                stroke="rgb(204 251 241)"
                 className="h-6 w-6"
               >
                 <path

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,7 +1,20 @@
+/**
+ * @file Defines core modal component functionality, and handles imports for
+ * all other sub-components.
+ *
+ * Originally had them all in one file, but the dot syntax for Modal was
+ * causing hot-module reloading to break. The syntax is still here, but because
+ * the source components are each in their own module, things shouldn't break.
+ */
 import { PropsWithChildren } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 
 import useModalBackground from "./useModalBackground";
+import ModalLink from "./ModalLink";
+import ModalListItem from "./ModalListItem";
+import ModalList from "./ModalList";
+import ModalParagraph from "./ModalParagraph";
+import ModalSubsection from "./ModalSubsection";
 
 type ModalProps = PropsWithChildren<{
   buttonText: string;
@@ -30,13 +43,13 @@ function CoreContent({ children, modalTitle, modalDescription }: CoreProps) {
 
       <Dialog.Content
         ref={contentRef}
-        className="z-20 h-full w-full max-w-prose overflow-y-auto bg-teal-950 p-10 shadow-md"
+        className="z-20 h-full w-full max-w-prose overflow-y-auto bg-teal-950 p-10 pb-2 shadow-md"
       >
-        <Dialog.Title className="mb-1 text-4xl font-extralight italic opacity-80">
+        <Dialog.Title className="mb-1 text-4xl font-extralight italic text-teal-100 opacity-[85%]">
           {modalTitle}
         </Dialog.Title>
 
-        <Dialog.Description className="mb-4 pb-1 italic opacity-80">
+        <Dialog.Description className="mb-6 border-b-2 border-teal-200 pb-3 italic text-teal-100">
           {modalDescription}
         </Dialog.Description>
 
@@ -85,52 +98,14 @@ function Modal({ buttonText, ...delegated }: ModalProps) {
   );
 }
 
-type SubheaderProps = {
-  children: string;
-};
-
-Modal.Subheader = function ModalSubheader({ children }: SubheaderProps) {
-  return <h3>{children}</h3>;
-};
-
-type ParagraphProps = PropsWithChildren<{
-  italicized?: boolean;
-}>;
-
-Modal.Paragraph = function ModalParagraph({
-  children,
-  italicized = false,
-}: ParagraphProps) {
-  return <p className={`${italicized ? "italic" : ""}`}>{children}</p>;
-};
-
-type ListProps = PropsWithChildren<{
-  ordered?: boolean;
-}>;
-
-Modal.List = function ModalNumberedList({
-  children,
-  ordered = false,
-}: ListProps) {
-  const ListTag = ordered ? "ol" : "ul";
-  return <ListTag>{children}</ListTag>;
-};
-
-Modal.ListItem = function ModalListItem({ children }: PropsWithChildren) {
-  return <li>{children}</li>;
-};
-
-type LinkProps = {
-  href: string;
-  children: string;
-};
-
-Modal.Link = function ModalLink({ href, children }: LinkProps) {
-  return (
-    <a href={href} target="_blank" rel="noreferrer">
-      {children}
-    </a>
-  );
-};
+// Really wanted to have these function components all in the same file,
+// because none of them are that big, but when I did that, I broke Vite's hot-
+// module reloading for the dev environment. I don't think it would ever cause a
+// problem in production, but better to be safe than sorry
+Modal.Subsection = ModalSubsection;
+Modal.Paragraph = ModalParagraph;
+Modal.List = ModalList;
+Modal.ListItem = ModalListItem;
+Modal.Link = ModalLink;
 
 export default Modal;

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -43,7 +43,7 @@ type CoreProps = Omit<ModalProps, "buttonText">;
  * component, you keep getting errors in the console.
  *
  * Had to wire up the Radix ref manually because I couldn't find a good way to
- * restructure the HTML without losing all the necessary containers for my
+ * restructure the HTML without losing all the containers necessary for my
  * needlessly fancy styling
  */
 const CoreContent = forwardRef(function CoreContent(
@@ -66,7 +66,7 @@ const CoreContent = forwardRef(function CoreContent(
          * part of the content container (without covering up any text) when
          * the window gets small enough
          */}
-        <div className="relative mb-6 flex flex-row gap-x-3 border-b-2 pb-3 lg:static">
+        <div className="relative mb-6 flex flex-row gap-x-3 border-b-2 border-teal-200 pb-3 lg:static">
           <section className="flex-grow">
             <Dialog.Title
               className="mb-0.5 text-4xl font-extralight italic leading-snug text-teal-100 opacity-[85%]"
@@ -85,7 +85,7 @@ const CoreContent = forwardRef(function CoreContent(
 
           <Dialog.Close asChild>
             <button
-              className="block flex-shrink-0 self-start rounded-full border-2 border-teal-100 bg-teal-900 stroke-teal-100 p-4 outline outline-4 outline-teal-900 transition-colors duration-150 hover:bg-teal-800 hover:outline-teal-800 lg:absolute lg:right-12 lg:top-10"
+              className="block flex-shrink-0 self-start rounded-full border-2 border-teal-100 bg-teal-950 stroke-teal-100 p-4 outline outline-4 outline-teal-950 transition-colors duration-150 hover:bg-teal-900 hover:outline-teal-900 lg:absolute lg:right-12 lg:top-10"
               aria-label="Close modal"
             >
               <svg

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -35,47 +35,50 @@ type CoreProps = Omit<ModalProps, "buttonText">;
  * values to read from.
  */
 function CoreContent({ children, modalTitle, modalDescription }: CoreProps) {
-  const { contentRef, backgroundRef } = useModalBackground();
+  const { contentRef, topBgRef, bottomBgRef } = useModalBackground();
 
   return (
     <div className="fixed left-0 top-0 flex h-full w-full flex-col items-center justify-center text-teal-50">
-      <div ref={backgroundRef} className="fixed z-10 bg-teal-950" />
+      <div ref={bottomBgRef} className="fixed z-10 bg-teal-200" />
+      <div ref={topBgRef} className="fixed z-10 bg-teal-950" />
 
       <Dialog.Content
         ref={contentRef}
         className="z-20 h-full w-full max-w-prose overflow-y-auto bg-teal-950 p-10 pb-2 shadow-md"
       >
-        <Dialog.Title className="mb-1 text-4xl font-extralight italic text-teal-100 opacity-[85%]">
-          {modalTitle}
-        </Dialog.Title>
+        <section>
+          <Dialog.Title className="mb-1 text-4xl font-extralight italic text-teal-100 opacity-[85%]">
+            {modalTitle}
+          </Dialog.Title>
 
-        <Dialog.Description className="mb-6 border-b-2 border-teal-200 pb-3 italic text-teal-100">
-          {modalDescription}
-        </Dialog.Description>
+          <Dialog.Description className="mb-6 border-b-2 border-teal-200 pb-3 italic text-teal-100">
+            {modalDescription}
+          </Dialog.Description>
+
+          <Dialog.Close asChild>
+            <button
+              className="absolute right-12 top-10 block rounded-full border-2 border-teal-100 bg-teal-900 p-4 outline outline-4 outline-teal-900"
+              aria-label="Close modal"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={2}
+                stroke="rgb(204 251 241)"
+                className="h-6 w-6"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </Dialog.Close>
+        </section>
 
         <div className="overflow-y-auto">{children}</div>
-
-        <Dialog.Close asChild>
-          <button
-            className="absolute right-12 top-10 block rounded-full border-2 border-teal-100 bg-teal-900 p-4 outline outline-4 outline-teal-900"
-            aria-label="Close modal"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={2}
-              stroke="rgb(204 251 241)"
-              className="h-6 w-6"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
-          </button>
-        </Dialog.Close>
       </Dialog.Content>
     </div>
   );

--- a/src/components/Modal/ModalLink.tsx
+++ b/src/components/Modal/ModalLink.tsx
@@ -1,0 +1,17 @@
+type Props = {
+  href: string;
+  children: string;
+};
+
+export default function ModalLink({ href, children }: Props) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      className="underline decoration-teal-200 underline-offset-[3px]"
+    >
+      {children}
+    </a>
+  );
+}

--- a/src/components/Modal/ModalList.tsx
+++ b/src/components/Modal/ModalList.tsx
@@ -1,0 +1,20 @@
+import { PropsWithChildren } from "react";
+import { cva } from "class-variance-authority";
+
+type Props = PropsWithChildren<{
+  ordered?: boolean;
+}>;
+
+const listStyles = cva("list-outside pb-6 pl-7 leading-[1.6] last:pb-0", {
+  variants: {
+    ordered: {
+      true: "list-decimal",
+      false: "list-disc",
+    },
+  },
+});
+
+export default function ModalList({ children, ordered = false }: Props) {
+  const ListTag = ordered ? "ol" : "ul";
+  return <ListTag className={listStyles({ ordered })}>{children}</ListTag>;
+}

--- a/src/components/Modal/ModalListItem.tsx
+++ b/src/components/Modal/ModalListItem.tsx
@@ -1,0 +1,5 @@
+import { PropsWithChildren } from "react";
+
+export default function ModalListItem({ children }: PropsWithChildren) {
+  return <li className="pb-2 pl-2.5 last:pb-0">{children}</li>;
+}

--- a/src/components/Modal/ModalParagraph.tsx
+++ b/src/components/Modal/ModalParagraph.tsx
@@ -1,0 +1,16 @@
+import { PropsWithChildren } from "react";
+
+type Props = PropsWithChildren<{
+  italicized?: boolean;
+}>;
+
+export default function ModalParagraph({
+  children,
+  italicized = false,
+}: Props) {
+  return (
+    <p className={`${italicized ? "italic" : ""} pb-2 leading-[1.7]`}>
+      {children}
+    </p>
+  );
+}

--- a/src/components/Modal/ModalSubsection.tsx
+++ b/src/components/Modal/ModalSubsection.tsx
@@ -1,0 +1,14 @@
+import { PropsWithChildren } from "react";
+
+type Props = PropsWithChildren<{
+  title: string;
+}>;
+
+export default function ModalSubsection({ title, children }: Props) {
+  return (
+    <section className="pb-6">
+      <h3 className="pb-1 text-2xl font-normal italic">{title}</h3>
+      {children}
+    </section>
+  );
+}

--- a/src/components/Modal/index.ts
+++ b/src/components/Modal/index.ts
@@ -1,0 +1,2 @@
+export * from "./Modal";
+export { default } from "./Modal";

--- a/src/components/Modal/useModalBackground.ts
+++ b/src/components/Modal/useModalBackground.ts
@@ -2,13 +2,18 @@ import { useLayoutEffect, useRef } from "react";
 
 export default function useModalBackground() {
   const contentRef = useRef<HTMLDivElement>(null);
-  const backgroundRef = useRef<HTMLDivElement>(null);
+  const topBgRef = useRef<HTMLDivElement>(null);
+  const bottomBgRef = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
     const syncBackgroundWithContent = () => {
       const content = contentRef.current;
-      const background = backgroundRef.current;
-      if (content === null || background === null) return;
+      const topBg = topBgRef.current;
+      const bottomBg = bottomBgRef.current;
+
+      if (content === null || topBg === null || bottomBg === null) {
+        return;
+      }
 
       const containerWidth = content.offsetWidth;
       const viewportWidth = window.innerWidth;
@@ -18,12 +23,17 @@ export default function useModalBackground() {
       const bgWidth = Math.round(Math.sqrt(containerWidth ** 2 + heightSq));
       const bgHeight = Math.round(Math.sqrt(viewportWidth ** 2 + heightSq));
 
-      // Need to figure out actual formula
-      const bgRotation = -35;
+      // Need to figure out actual formula for bg1Rotation
+      const bg1Rotation = -35;
+      const bg2Rotation = Math.max(-90, bg1Rotation - 7);
 
-      background.style.width = `${bgWidth}px`;
-      background.style.height = `${bgHeight}px`;
-      background.style.transform = `rotate(${bgRotation}deg)`;
+      topBg.style.width = `${bgWidth}px`;
+      topBg.style.height = `${bgHeight}px`;
+      topBg.style.transform = `rotate(${bg1Rotation}deg)`;
+
+      bottomBg.style.width = `${bgWidth}px`;
+      bottomBg.style.height = `${bgHeight}px`;
+      bottomBg.style.transform = `rotate(${bg2Rotation}deg)`;
     };
 
     // Can't observe content element itself, because it'll stop triggering the
@@ -36,5 +46,5 @@ export default function useModalBackground() {
     return () => observer.disconnect();
   }, []);
 
-  return { contentRef, backgroundRef } as const;
+  return { contentRef, topBgRef, bottomBgRef } as const;
 }

--- a/src/components/Modal/useModalBackground.ts
+++ b/src/components/Modal/useModalBackground.ts
@@ -1,0 +1,41 @@
+import { useLayoutEffect, useRef } from "react";
+
+export default function useModalBackground() {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const backgroundRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const content = contentRef.current;
+    if (content === null) return;
+
+    const syncBackgroundWithContent: ResizeObserverCallback = (entries) => {
+      const content = contentRef.current;
+      const background = backgroundRef.current;
+      if (content === null || background === null) return;
+
+      const sizeInfo = entries[0]?.borderBoxSize[0];
+      if (sizeInfo === undefined) return;
+
+      const containerWidth = sizeInfo.inlineSize;
+      const viewportWidth = window.innerWidth;
+      const height = window.innerHeight;
+
+      const heightSq = height ** 2;
+      const bgWidth = Math.round(Math.sqrt(containerWidth ** 2 + heightSq));
+      const bgHeight = Math.round(Math.sqrt(viewportWidth ** 2 + heightSq));
+
+      // Need to figure out actual formula
+      const bgRotation = -35;
+
+      background.style.width = `${bgWidth}px`;
+      background.style.height = `${bgHeight}px`;
+      background.style.transform = `rotate(${bgRotation}deg)`;
+    };
+
+    const observer = new ResizeObserver(syncBackgroundWithContent);
+    observer.observe(content);
+    return () => observer.disconnect();
+  }, []);
+
+  return { contentRef, backgroundRef } as const;
+}

--- a/src/components/Modal/useModalBackground.ts
+++ b/src/components/Modal/useModalBackground.ts
@@ -23,7 +23,11 @@ export default function useModalBackground() {
       const bgWidth = Math.round(Math.sqrt(containerWidth ** 2 + heightSq));
       const bgHeight = Math.round(Math.sqrt(viewportWidth ** 2 + heightSq));
 
-      // Need to figure out actual formula for bg1Rotation
+      /**
+       * @todo Hard-coded -35 degrees seems to work well for most sizes, but
+       * really need to figure out the right formula to ensure rotation is as
+       * accurate as possible
+       */
       const bg1Rotation = -35;
       const bg2Rotation = Math.max(-90, bg1Rotation - 7);
 

--- a/src/components/Modal/useModalBackground.ts
+++ b/src/components/Modal/useModalBackground.ts
@@ -5,18 +5,12 @@ export default function useModalBackground() {
   const backgroundRef = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
-    const content = contentRef.current;
-    if (content === null) return;
-
-    const syncBackgroundWithContent: ResizeObserverCallback = (entries) => {
+    const syncBackgroundWithContent = () => {
       const content = contentRef.current;
       const background = backgroundRef.current;
       if (content === null || background === null) return;
 
-      const sizeInfo = entries[0]?.borderBoxSize[0];
-      if (sizeInfo === undefined) return;
-
-      const containerWidth = sizeInfo.inlineSize;
+      const containerWidth = content.offsetWidth;
       const viewportWidth = window.innerWidth;
       const height = window.innerHeight;
 
@@ -32,8 +26,13 @@ export default function useModalBackground() {
       background.style.transform = `rotate(${bgRotation}deg)`;
     };
 
+    // Can't observe content element itself, because it'll stop triggering the
+    // observer callback if you keep resizing the window after the content has
+    // hits its max width. At the same time, can't read the observed values
+    // through the callback parameters, or else you'll have data on the body,
+    // not the content
     const observer = new ResizeObserver(syncBackgroundWithContent);
-    observer.observe(content);
+    observer.observe(document.body, { box: "border-box" });
     return () => observer.disconnect();
   }, []);
 


### PR DESCRIPTION
This commit gets a new version of the modals in place that match the design of the rest of the app a lot more. Pushing this out to get the app looking more consistent, but there are some things left to do:
- Get Proza Display integrated into the app (this is a licensed font, so I have to host this somewhere like S3 – absolutely can't just drop the file in the repo)
- Figure out a dynamic formula for making sure the rotation on the modal backgrounds stays as accurate as possible as the window resizes. Currently using a hard-coded value, which seems to work pretty well, but we can do better