### PR TITLE
minor: Ensure that data and images are ready before load transition

### DIFF
--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import useEditorController from "./useEditorController";
+import useInitialViewStatus from "./useInitialViewStatus";
 
 import CharacterPreview from "@/components/CharacterPreview";
 import LoadingIndicator from "@/components/LoadingIndicator";
@@ -7,14 +8,18 @@ import CharacterMenus from "@/components/CharacterMenus";
 import ColorMenus from "@/components/ColorMenus";
 
 export default function Editor() {
-  const editorController = useEditorController();
   const [introAnimationFinished, setIntroAnimationFinished] = useState(false);
+  const editorController = useEditorController();
+  const initialViewReady = useInitialViewStatus(
+    editorController.initialized,
+    editorController.derived?.selectedCharacter.imgUrl ?? null
+  );
 
   return (
     <div className="h-full">
       {!introAnimationFinished && (
         <LoadingIndicator
-          appLoaded={editorController.initialized}
+          appLoaded={initialViewReady}
           onAnimationCompletion={() => setIntroAnimationFinished(true)}
         />
       )}

--- a/src/components/Editor/useInitialViewStatus.ts
+++ b/src/components/Editor/useInitialViewStatus.ts
@@ -1,0 +1,38 @@
+/**
+ * @file Slightly wonky hook for making sure that the app is only treated as
+ * being fully loaded once both the editor data and the initial image have been
+ * loaded in.
+ *
+ * Kept running into cases (especially on bad connections) where the editor
+ * state would load faster than the image, leading to the user seeing a loading
+ * screen on the canvas – right after sitting through another loading screen
+ *
+ * The vast majority of apps do not need to do this – it's a safeguard that's
+ * needed here because this app involves direct image manipulation. Without an
+ * image, the app is useless.
+ */
+import { useState } from "react";
+import useBitmapManager from "@/hooks/useBitmapManager";
+
+export default function useInitialViewStatus(
+  editorInitialized: boolean,
+  imageUrl: string | null
+) {
+  const [ready, setReady] = useState(false);
+  const [initialUrl, setInitialUrl] = useState(imageUrl);
+  const { status: imageStatus } = useBitmapManager(initialUrl);
+
+  const firstImageLoaded = initialUrl === null && typeof imageUrl === "string";
+  if (firstImageLoaded) {
+    setInitialUrl(imageUrl);
+  }
+
+  const editorAndImageReady =
+    editorInitialized && imageStatus !== "idle" && imageStatus !== "loading";
+
+  if (!ready && editorAndImageReady) {
+    setReady(true);
+  }
+
+  return ready;
+}

--- a/src/hooks/useBitmapManager.ts
+++ b/src/hooks/useBitmapManager.ts
@@ -98,7 +98,8 @@ class ImageCache {
     return this.#mutableCache.get(imgUrl) ?? null;
   }
 
-  getSnapshot(imgUrl: string): ReactSnapshot {
+  getSnapshot(imgUrl: string | null): ReactSnapshot {
+    if (imgUrl === null) return ImageCache.defaultSnapshot;
     return this.#immutableSnapshots.get(imgUrl) ?? ImageCache.defaultSnapshot;
   }
 
@@ -185,7 +186,7 @@ function subscribeReactToCache(notifyReact: () => void) {
   return () => cache.removeSubscription(notifyReact);
 }
 
-export default function useBitmapManager(imgUrl: string) {
+export default function useBitmapManager(imgUrl: string | null) {
   const { bitmap, status, error } = useSyncExternalStore(
     subscribeReactToCache,
     () => cache.getSnapshot(imgUrl)


### PR DESCRIPTION
This addresses an issue that mainly happened on slow connections.

Basically, the app was only set up to detect whether the character data had been loaded in, and would only be waiting for that before clearing the loading screen. However, because this is an application that involves direct image manipulation, that could lead to situations where the editor would be loaded, but the image wouldn't be. It's not a great look to sit through a loading screen, and then immediately see more loading.