### PR TITLE
Keyboard a11y for character menus

### DIFF
--- a/src/components/CharacterMenus/CharacterButton.tsx
+++ b/src/components/CharacterMenus/CharacterButton.tsx
@@ -11,7 +11,7 @@ const buttonStyles = cva(
   {
     variants: {
       selected: {
-        true: "cursor-not-allowed bg-teal-200 text-teal-800",
+        true: "cursor-default bg-teal-200 text-teal-800",
         false:
           "bg-teal-700 text-teal-100 hover:bg-teal-200 hover:text-teal-800",
       },
@@ -29,7 +29,7 @@ export default function CharacterButton({
       type="button"
       className={buttonStyles({ selected })}
       onClick={onClick}
-      disabled={selected}
+      tabIndex={selected ? 0 : -1}
     >
       {children}
     </button>

--- a/src/components/CharacterMenus/CharacterButton.tsx
+++ b/src/components/CharacterMenus/CharacterButton.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from "react";
+import { PropsWithChildren, forwardRef } from "react";
 import { cva } from "class-variance-authority";
 
 type Props = PropsWithChildren<{
@@ -19,13 +19,13 @@ const buttonStyles = cva(
   }
 );
 
-export default function CharacterButton({
-  selected,
-  onClick,
-  children,
-}: Props) {
+const CharacterButton = forwardRef(function CharacterButton(
+  { selected, onClick, children }: Props,
+  ref?: React.ForwardedRef<HTMLButtonElement>
+) {
   return (
     <button
+      ref={ref}
       type="button"
       className={buttonStyles({ selected })}
       onClick={onClick}
@@ -34,4 +34,6 @@ export default function CharacterButton({
       {children}
     </button>
   );
-}
+});
+
+export default CharacterButton;

--- a/src/components/CharacterMenus/CharacterClassPanel.tsx
+++ b/src/components/CharacterMenus/CharacterClassPanel.tsx
@@ -11,6 +11,7 @@ type Props = {
   characters: readonly Character[];
   selectedCharacterId: string;
   onCharacterChange: (newCharacter: Character) => void;
+  activeButtonRef?: React.ForwardedRef<HTMLButtonElement>;
 };
 
 export default function CharacterClassSection({
@@ -18,6 +19,7 @@ export default function CharacterClassSection({
   characters,
   selectedCharacterId,
   onCharacterChange,
+  activeButtonRef,
 }: Props) {
   const HeaderTag = useCurrentHeader();
   const placeholderSlotsToRender = Math.abs((5 - characters.length) % 5);
@@ -36,24 +38,24 @@ export default function CharacterClassSection({
             </div>
           ) : (
             <ul className="grid h-full w-full grid-cols-5 gap-x-2">
-              {characters.map((char) => (
-                // Could make the images load on hover, but because the UI is
-                // going to be so dense and have so many buttons, each of which
-                // has a big image associated with it (whether that loads on
-                // hover or click), it felt like it'd be way too easy to clog
-                // things with network requests with the hover approach
-                <li key={char.id}>
-                  <CharacterButton
-                    selected={char.id === selectedCharacterId}
-                    onClick={() => onCharacterChange(char)}
-                  >
-                    <VisuallyHidden.Root>
-                      Select {char.class}{" "}
-                    </VisuallyHidden.Root>
-                    {char.displayId}
-                  </CharacterButton>
-                </li>
-              ))}
+              {characters.map((char) => {
+                const selected = char.id === selectedCharacterId;
+
+                return (
+                  <li key={char.id}>
+                    <CharacterButton
+                      selected={selected}
+                      onClick={() => onCharacterChange(char)}
+                      ref={selected ? activeButtonRef : undefined}
+                    >
+                      <VisuallyHidden.Root>
+                        Select {char.class}{" "}
+                      </VisuallyHidden.Root>
+                      {char.displayId}
+                    </CharacterButton>
+                  </li>
+                );
+              })}
 
               {range(placeholderSlotsToRender).map((num) => (
                 <li

--- a/src/components/CharacterMenus/localHelpers.ts
+++ b/src/components/CharacterMenus/localHelpers.ts
@@ -4,12 +4,13 @@ import {
   ClassOrderings,
 } from "@/typesConstants/gameData";
 
-type GroupEntry = { class: string; characters: readonly Character[] };
+export type GroupEntry = { class: string; characters: readonly Character[] };
+export type GroupData = Map<GameOrigin, readonly GroupEntry[]>;
 
 export function groupCharacters(
   characters: readonly Character[],
   classOrderings: ClassOrderings
-): Map<GameOrigin, readonly GroupEntry[]> {
+): GroupData {
   const sortedChars = [...characters].sort((char1, char2) => {
     if (char1.displayId === char2.displayId) return 0;
     return char1.displayId < char2.displayId ? -1 : 1;

--- a/src/components/CharacterMenus/useKeyboardNavigation.ts
+++ b/src/components/CharacterMenus/useKeyboardNavigation.ts
@@ -1,0 +1,135 @@
+import { Character } from "@/typesConstants/gameData";
+import { GroupData, GroupEntry } from "./localHelpers";
+import { useEffect, useRef } from "react";
+
+const arrowKeys = ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"] as const;
+type ArrowKey = (typeof arrowKeys)[number];
+
+function isArrowKey(value: unknown): value is ArrowKey {
+  return typeof value === "string" && arrowKeys.includes(value as ArrowKey);
+}
+
+let lastGroup: GroupData | null = null;
+let cachedGroupIterable: readonly GroupEntry[] = [];
+
+export function findNewCharacterFromInput(
+  characterGroups: GroupData,
+  currentCharacter: Character,
+  arrowKey: ArrowKey
+): Character | null {
+  const activeEntry = characterGroups
+    .get(currentCharacter.game)
+    ?.find((entry) => entry.class === currentCharacter.class);
+
+  if (activeEntry === undefined) {
+    return null;
+  }
+
+  const activeClassList = activeEntry.characters;
+  const activeCharIndex = activeClassList.findIndex(
+    (char) => char === currentCharacter
+  );
+
+  // Handles left and right inputs; really straightforward
+  if (arrowKey === "ArrowLeft") {
+    const newCharacter = activeClassList[activeCharIndex - 1];
+    return newCharacter ?? null;
+  }
+
+  if (arrowKey === "ArrowRight") {
+    const newCharacter = activeClassList[activeCharIndex + 1];
+    return newCharacter ?? null;
+  }
+
+  // Rest of the function handles up/down inputs; much more involved
+  if (lastGroup !== characterGroups) {
+    lastGroup = characterGroups;
+    cachedGroupIterable = [...characterGroups.values()].flat();
+  }
+
+  if (arrowKey === "ArrowUp") {
+    let prevEntry = cachedGroupIterable.at(0);
+
+    for (const entry of cachedGroupIterable) {
+      if (entry === activeEntry) break;
+      if (entry.characters.length > 0) {
+        prevEntry = entry;
+      }
+    }
+
+    if (prevEntry === undefined || prevEntry === activeEntry) {
+      return null;
+    }
+
+    const prevClassList = prevEntry.characters;
+    const newIndex = Math.min(activeCharIndex, prevClassList.length - 1);
+    return prevClassList[newIndex] ?? null;
+  }
+
+  if (arrowKey === "ArrowDown") {
+    let nextEntry = cachedGroupIterable.at(-1);
+
+    for (let i = cachedGroupIterable.length - 1; i >= 0; i--) {
+      const entry = cachedGroupIterable[i];
+      if (entry === undefined || entry === activeEntry) break;
+
+      if (entry.characters.length > 0) {
+        nextEntry = entry;
+      }
+    }
+
+    if (nextEntry === undefined || nextEntry === activeEntry) {
+      return null;
+    }
+
+    const nextClassList = nextEntry.characters;
+    const newIndex = Math.min(activeCharIndex, nextClassList.length - 1);
+    return nextClassList[newIndex] ?? null;
+  }
+
+  return null;
+}
+
+export default function useKeyboardNavigation(
+  characterGroups: GroupData,
+  character: Character,
+  onCharacterChange: (newCharacter: Character) => void
+) {
+  const elementRef = useRef<HTMLDivElement>(null);
+
+  const groupRef = useRef(characterGroups);
+  const characterRef = useRef(character);
+  const charChangeRef = useRef(onCharacterChange);
+
+  useEffect(() => {
+    groupRef.current = characterGroups;
+    characterRef.current = character;
+    charChangeRef.current = onCharacterChange;
+  }, [characterGroups, character, onCharacterChange]);
+
+  useEffect(() => {
+    const element = elementRef.current;
+    if (!element) return;
+
+    const handleKeyboardInput = (event: KeyboardEvent) => {
+      const { key } = event;
+      if (!isArrowKey(key)) return;
+
+      event.preventDefault();
+      const newCharacter = findNewCharacterFromInput(
+        groupRef.current,
+        characterRef.current,
+        key
+      );
+
+      if (newCharacter !== null) {
+        charChangeRef.current(newCharacter);
+      }
+    };
+
+    element.addEventListener("keydown", handleKeyboardInput);
+    return () => element.removeEventListener("keydown", handleKeyboardInput);
+  }, []);
+
+  return elementRef;
+}

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -28,7 +28,7 @@ export default function Editor() {
         {editorController.initialized && (
           <div className="mx-auto mb-6 flex h-full w-full max-w-[1700px] flex-grow flex-row items-center justify-between gap-x-8">
             <CharacterMenus
-              selectedCharacterId={editorController.editor.selectedId}
+              selectedCharacter={editorController.derived.selectedCharacter}
               characters={editorController.server.characters}
               classOrderings={editorController.server.classOrderings}
               onCharacterChange={editorController.editor.changeCharacter}

--- a/src/components/OverflowContainer/OverflowContainer.tsx
+++ b/src/components/OverflowContainer/OverflowContainer.tsx
@@ -1,19 +1,19 @@
-import { PropsWithChildren } from "react";
+import { PropsWithChildren, forwardRef } from "react";
 import styles from "./scrollbar.module.css";
 
-type ContainerProps = PropsWithChildren<{
-  inputGroup?: boolean;
-}>;
-
-function OverflowContainer({ children, inputGroup }: ContainerProps) {
-  const MainContainerElement = inputGroup ? "fieldset" : "section";
-
+const OverflowContainer = forwardRef(function OverflowContainer(
+  { children }: PropsWithChildren,
+  ref?: React.ForwardedRef<HTMLDivElement>
+) {
   return (
-    <MainContainerElement className="flex h-full w-[430px] shrink-0 flex-col flex-nowrap">
+    <div
+      ref={ref}
+      className="flex h-full w-[430px] shrink-0 flex-col flex-nowrap"
+    >
       {children}
-    </MainContainerElement>
+    </div>
   );
-}
+});
 
 export function OverflowContainerHeader({ children }: PropsWithChildren) {
   return (
@@ -23,7 +23,7 @@ export function OverflowContainerHeader({ children }: PropsWithChildren) {
   );
 }
 
-export function OverflowContainerContent({ children }: PropsWithChildren) {
+export function OverflowContainerFlexContent({ children }: PropsWithChildren) {
   /*
    * 2023-06-09 - This is a really weird trick to avoid a strange CSS bug
    * specific to Chrome. (Firefox did not have this issue.)
@@ -75,8 +75,15 @@ export function OverflowContainerFooterButton({
   );
 }
 
-OverflowContainer.Root = OverflowContainer;
-OverflowContainer.Header = OverflowContainerHeader;
-OverflowContainer.FlexContent = OverflowContainerContent;
-OverflowContainer.FooterButton = OverflowContainerFooterButton;
-export default OverflowContainer;
+const ContainerRecast = OverflowContainer as typeof OverflowContainer & {
+  Root: typeof OverflowContainer;
+  Header: typeof OverflowContainerHeader;
+  FlexContent: typeof OverflowContainerFlexContent;
+  FooterButton: typeof OverflowContainerFooterButton;
+};
+
+ContainerRecast.Root = OverflowContainer;
+ContainerRecast.Header = OverflowContainerHeader;
+ContainerRecast.FlexContent = OverflowContainerFlexContent;
+ContainerRecast.FooterButton = OverflowContainerFooterButton;
+export default ContainerRecast;

--- a/src/hooks/useBitmapManager.ts
+++ b/src/hooks/useBitmapManager.ts
@@ -166,6 +166,11 @@ class ImageCache {
 
 const cache = new ImageCache();
 
+/**
+ * Note: The reason why this function is available as a separate hook is so that
+ * components can access it without having to go through useBitmapManager, which
+ * requires an image URL as input
+ */
 export function useLazyImageLoader() {
   return useCallback((imgUrl: string, notifyAfterLoad = true) => {
     const info: NotificationInfo = {


### PR DESCRIPTION
This update takes a page out of Radix's book by updating `<CharacterMenus />` to add keyboard navigation and much better focus support.

Rather than treat every single button in the list as an equally-important element, this update groups them together, so that only the active button can be reached by tabbing, while you can use the arrow keys to navigate the individual buttons. If you try navigating to a button that is out of view of the overflow container, it will also scroll into view.