### PR TITLE
feat: Add usePresetKeyboardNav

### DIFF
--- a/src/components/CharacterMenus/CharacterMenus.tsx
+++ b/src/components/CharacterMenus/CharacterMenus.tsx
@@ -18,7 +18,7 @@ import { useLazyImageLoader } from "@/hooks/useBitmapManager";
 import HeaderProvider, { useCurrentHeader } from "@/contexts/HeaderLevels";
 
 import CharacterClassSection from "./CharacterClassPanel";
-import useKeyboardNavigation from "./useKeyboardNavigation";
+import useCharacterKeyboardNav from "./useCharacterKeyboardNav";
 
 type Props = {
   selectedCharacter: Character;
@@ -49,7 +49,7 @@ const CharacterMenus = memo(function CharacterMenus({
     [characters, classOrderings]
   );
 
-  const containerRef = useKeyboardNavigation(
+  const containerRef = useCharacterKeyboardNav(
     grouped,
     selectedCharacter,
     onCharacterChange

--- a/src/components/CharacterMenus/useCharacterKeyboardNav.ts
+++ b/src/components/CharacterMenus/useCharacterKeyboardNav.ts
@@ -1,17 +1,11 @@
+import { useEffect, useRef } from "react";
 import { Character } from "@/typesConstants/gameData";
+import { ArrowKey, isArrowKey } from "@/utils/keyboard";
 import {
   GroupData,
   GroupEntry,
   findGroupEntryFromCharacter,
 } from "./localHelpers";
-import { useEffect, useRef } from "react";
-
-const arrowKeys = ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"] as const;
-type ArrowKey = (typeof arrowKeys)[number];
-
-function isArrowKey(value: unknown): value is ArrowKey {
-  return typeof value === "string" && arrowKeys.includes(value as ArrowKey);
-}
 
 let lastGroup: GroupData | null = null;
 let cachedGroupIterable: readonly GroupEntry[] = [];

--- a/src/components/ColorMenus/ColorButton.tsx
+++ b/src/components/ColorMenus/ColorButton.tsx
@@ -1,5 +1,6 @@
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import classNames from "classnames";
+import { forwardRef } from "react";
 
 type Props = React.ComponentPropsWithoutRef<"button"> & {
   primaryHex: string;
@@ -10,13 +11,10 @@ type Props = React.ComponentPropsWithoutRef<"button"> & {
   selected?: boolean;
 };
 
-export default function ColorButton({
-  primaryHex,
-  secondaryHex,
-  children,
-  selected = false,
-  ...delegated
-}: Props) {
+const ColorButton = forwardRef(function ColorButton(
+  { primaryHex, secondaryHex, children, selected = false, ...delegated }: Props,
+  ref?: React.ForwardedRef<HTMLButtonElement>
+) {
   return (
     <div
       className={classNames(
@@ -25,6 +23,7 @@ export default function ColorButton({
       )}
     >
       <button
+        ref={ref}
         className="relative h-10 min-w-[80px] basis-[80px] overflow-y-hidden rounded-md border-2 border-black"
         style={{ backgroundColor: primaryHex }}
         {...delegated}
@@ -49,4 +48,6 @@ export default function ColorButton({
       </button>
     </div>
   );
-}
+});
+
+export default ColorButton;

--- a/src/components/ColorMenus/ColorMenus.tsx
+++ b/src/components/ColorMenus/ColorMenus.tsx
@@ -3,12 +3,7 @@
  * character.
  */
 import { Fragment } from "react";
-import { CharacterColors, MISC_COLOR_PRESETS } from "@/typesConstants/colors";
-import {
-  ColorTuple,
-  HAIR_EYE_COLOR_PRESETS,
-  SKIN_COLOR_PRESETS,
-} from "@/typesConstants/colors";
+import { CharacterColors } from "@/typesConstants/colors";
 
 import { UiTab, uiTabs } from "./localTypes";
 import useColorMenusState from "./useColorMenusState";
@@ -20,6 +15,7 @@ import * as Tabs from "@/components/Tabs";
 import Card from "@/components/Card";
 import ColorPicker from "@/components/ColorPicker";
 import OverflowContainer from "../OverflowContainer/OverflowContainer";
+import ColorPresets from "./ColorPresets";
 
 type ExternalProps = {
   /**
@@ -40,13 +36,6 @@ type CoreProps = Omit<ExternalProps, "characterKey">;
 
 // Using super bright magenta to make visual errors more obvious
 const fallbackColor = "#ff00ff";
-
-const colorPresets = {
-  eyes: HAIR_EYE_COLOR_PRESETS,
-  hair: HAIR_EYE_COLOR_PRESETS,
-  skin: SKIN_COLOR_PRESETS,
-  misc: MISC_COLOR_PRESETS,
-} as const satisfies Record<UiTab, readonly ColorTuple[]>;
 
 function ColorMenusCore({ colors, onColorChange, onColorsReset }: CoreProps) {
   const { state, updaters } = useColorMenusState(colors);
@@ -252,28 +241,10 @@ function ColorMenusCore({ colors, onColorChange, onColorsReset }: CoreProps) {
             <ColorPicker hexColor={activeHexColor} onHexChange={onHexChange} />
           </div>
 
-          {/* All the color presets associated with each tab */}
-          {colorPresets[state.activeTab].length > 0 && (
-            <div>
-              <Card
-                title={`Presets (${state.activeTab})`}
-                striped
-                gapSize="small"
-              >
-                <ul className="mt-1 grid w-full max-w-[400px] grid-cols-3 justify-between gap-3">
-                  {colorPresets[state.activeTab].map(([hex1, hex2], index) => (
-                    <li key={index} className="mx-auto block">
-                      <ColorButton
-                        primaryHex={hex1}
-                        secondaryHex={hex2}
-                        onClick={() => selectHexPreset(hex1, hex2)}
-                      />
-                    </li>
-                  ))}
-                </ul>
-              </Card>
-            </div>
-          )}
+          <ColorPresets
+            activeTab={state.activeTab}
+            onHexPresetChange={selectHexPreset}
+          />
         </OverflowContainer.FlexContent>
 
         <OverflowContainer.FooterButton onClick={onColorsReset}>

--- a/src/components/ColorMenus/ColorPresets.tsx
+++ b/src/components/ColorMenus/ColorPresets.tsx
@@ -32,40 +32,40 @@ export function mapKeyToGridIndex(
   const colIndex = currentIndex % gridCount;
   const lastRowIndex = Math.floor(itemCount / gridCount);
   const lastColIndex = Math.floor(itemCount / lastRowIndex);
-  const lastItemIndex = itemCount - 1;
 
-  // Only ArrowLeft seems to be 100% working right now
+  let offsetRowIndex = rowIndex;
+  let offsetColIndex = colIndex;
   switch (arrowKey) {
+    // Only ArrowLeft seems to be 100% working right now; all other arrows have
+    // issues if you're dealing with a grid that has blanks
     case "ArrowLeft": {
-      const offsetColIndex = colIndex === 0 ? gridCount - 1 : colIndex - 1;
-      const newRawIndex = lastColIndex * rowIndex + offsetColIndex;
-      return Math.min(newRawIndex, lastItemIndex);
+      offsetColIndex = colIndex === 0 ? gridCount - 1 : colIndex - 1;
+      break;
     }
 
     case "ArrowRight": {
-      // Current bug: the logic is not able to wrap around correctly if on a row
-      // that is not fully filled out
-      const offsetColIndex = colIndex === gridCount - 1 ? 0 : colIndex + 1;
-      const newRawIndex = lastColIndex * rowIndex + offsetColIndex;
-      return Math.min(newRawIndex, lastItemIndex);
+      offsetColIndex = colIndex === gridCount - 1 ? 0 : colIndex + 1;
+      break;
     }
 
     case "ArrowUp": {
-      const offsetRowIndex = rowIndex === 0 ? lastRowIndex : rowIndex - 1;
-      const newRawIndex = lastColIndex * offsetRowIndex + colIndex;
-      return Math.min(newRawIndex, lastItemIndex);
+      offsetRowIndex = rowIndex === 0 ? lastRowIndex : rowIndex - 1;
+      break;
     }
 
     case "ArrowDown": {
-      const offsetRowIndex = rowIndex === lastRowIndex ? 0 : rowIndex + 1;
-      const newRawIndex = lastColIndex * offsetRowIndex + colIndex;
-      return Math.min(newRawIndex, lastItemIndex);
+      offsetRowIndex = rowIndex === lastRowIndex ? 0 : rowIndex + 1;
+      break;
     }
 
     default: {
       throw new Error("Unknown input received.");
     }
   }
+
+  const lastItemIndex = itemCount - 1;
+  const computedIndex = lastColIndex * offsetRowIndex + offsetColIndex;
+  return Math.min(computedIndex, lastItemIndex);
 }
 
 function usePresetsKeyboardNav<Element extends HTMLElement>(

--- a/src/components/ColorMenus/ColorPresets.tsx
+++ b/src/components/ColorMenus/ColorPresets.tsx
@@ -1,169 +1,23 @@
-/**
- * @todo This file is getting big and involved enough that it probably makes
- * sense to split it off into a separate top-level directory once I'm done
- */
-import { useCallback, useEffect, useRef, useState } from "react";
-
 import {
   ColorTuple,
   HAIR_EYE_COLOR_PRESETS,
   SKIN_COLOR_PRESETS,
   MISC_COLOR_PRESETS,
 } from "@/typesConstants/colors";
-import { ArrowKey, isArrowKey } from "@/utils/keyboard";
-import { clamp } from "@/utils/math";
 
 import Card from "@/components/Card/";
 import ColorButton from "./ColorButton";
 import { UiTab } from "./localTypes";
+import usePresetsKeyboardNav from "./usePresetsKeyboardNav";
 
-type Props = {
+type ExternalProps = {
   activeTab: UiTab;
   onHexPresetChange: (hex1: string, hex2: string) => void;
 };
 
-export function mapKeyToGridIndex(
-  itemCount: number,
-  gridCount: number,
-  currentIndex: number,
-  arrowKey: ArrowKey
-): number {
-  const rowIndex = Math.floor(currentIndex / gridCount);
-  const colIndex = currentIndex % gridCount;
-  const lastRowIndex = Math.floor(itemCount / gridCount);
-  const lastColIndex = Math.floor(itemCount / lastRowIndex);
-
-  let offsetRowIndex = rowIndex;
-  let offsetColIndex = colIndex;
-  switch (arrowKey) {
-    // Only ArrowLeft seems to be 100% working right now; all other arrows have
-    // issues if you're dealing with a grid that has blanks
-    case "ArrowLeft": {
-      offsetColIndex = colIndex === 0 ? gridCount - 1 : colIndex - 1;
-      break;
-    }
-
-    case "ArrowRight": {
-      offsetColIndex = colIndex === gridCount - 1 ? 0 : colIndex + 1;
-      break;
-    }
-
-    case "ArrowUp": {
-      offsetRowIndex = rowIndex === 0 ? lastRowIndex : rowIndex - 1;
-      break;
-    }
-
-    case "ArrowDown": {
-      offsetRowIndex = rowIndex === lastRowIndex ? 0 : rowIndex + 1;
-      break;
-    }
-
-    default: {
-      throw new Error("Unknown input received.");
-    }
-  }
-
-  const lastItemIndex = itemCount - 1;
-  const computedIndex = lastColIndex * offsetRowIndex + offsetColIndex;
-  return Math.min(computedIndex, lastItemIndex);
-}
-
-function usePresetsKeyboardNav<Element extends HTMLElement>(
-  numPresets: number
-) {
-  const [activePresetIndex, setActivePresetIndex] = useState(0);
-
-  // Pretty sure I can get away with just using a ref value for the column
-  // count, since the value will only ever be used within effects
-  const gridColumnCountRef = useRef(0);
-  const gridContainerRef = useRef<Element>(null);
-  const updateInfoRef = useRef({ activePresetIndex, numPresets });
-
-  // Effect for updating the number of columns as the element resizes
-  useEffect(() => {
-    const gridContainer = gridContainerRef.current;
-    if (gridContainer === null) return;
-
-    const updateColumnCountOnResize = () => {
-      const gridStyling = window.getComputedStyle(gridContainer);
-      const count = gridStyling
-        .getPropertyValue("grid-template-columns")
-        .split(" ").length;
-
-      gridColumnCountRef.current = count;
-    };
-
-    const observer = new ResizeObserver(updateColumnCountOnResize);
-    observer.observe(gridContainer);
-    return () => observer.disconnect();
-  }, []);
-
-  useEffect(() => {
-    updateInfoRef.current = { activePresetIndex, numPresets };
-  }, [numPresets, activePresetIndex]);
-
-  // Effect for listening to keyboard input; must run after column resize effect
-  useEffect(() => {
-    const gridContainer = gridContainerRef.current;
-    if (gridContainer === null) return;
-
-    const handleKeyInput = (event: KeyboardEvent) => {
-      const { key } = event;
-      if (!isArrowKey(key)) return;
-
-      event.preventDefault();
-      const { activePresetIndex, numPresets } = updateInfoRef.current;
-
-      if (numPresets === 0) {
-        return;
-      }
-
-      const newIndex = mapKeyToGridIndex(
-        numPresets,
-        gridColumnCountRef.current,
-        activePresetIndex,
-        key
-      );
-
-      setActivePresetIndex(newIndex);
-    };
-
-    gridContainer.addEventListener("keydown", handleKeyInput);
-    return () => gridContainer.removeEventListener("keydown", handleKeyInput);
-  }, []);
-
-  /**
-   * @todo Effect is only for debugging - delete once fully done (and tested!)
-   */
-  useEffect(() => {
-    const gridContainer = gridContainerRef.current;
-    if (gridContainer === null) return;
-
-    const intervalId = window.setInterval(() => {
-      gridContainer.dispatchEvent(
-        new KeyboardEvent("keydown", { key: "ArrowRight" })
-      );
-    }, 500);
-
-    return () => window.clearInterval(intervalId);
-  }, []);
-
-  const safeSetActivePresetIndex = useCallback(
-    (newIndex: number) => {
-      setActivePresetIndex((current) => {
-        if (!Number.isInteger(newIndex) || newIndex < 0) return current;
-        return clamp(newIndex, 0, numPresets - 1);
-      });
-    },
-    [numPresets]
-  );
-
-  return {
-    gridContainerRef,
-    activePresetIndex,
-    setActivePresetIndex: safeSetActivePresetIndex,
-  } as const;
-}
+type CoreProps = Omit<ExternalProps, "activeTab"> & {
+  colorTuples: readonly ColorTuple[];
+};
 
 const colorPresets = {
   eyes: HAIR_EYE_COLOR_PRESETS,
@@ -172,17 +26,7 @@ const colorPresets = {
   misc: MISC_COLOR_PRESETS,
 } as const satisfies Record<UiTab, readonly ColorTuple[]>;
 
-type PresetsListProps = Omit<Props, "activeTab"> & {
-  colorTuples: readonly ColorTuple[];
-};
-
-/**
- * @todo Make empty state for when colors aren't available
- * @todo Extract out the arrow key logic into a separate utils file
- * @todo Also need to figure out how tab indexing and keyboard navigation even
- * work here.
- */
-function ColorPresetList({ colorTuples, onHexPresetChange }: PresetsListProps) {
+function ColorPresetsCore({ colorTuples, onHexPresetChange }: CoreProps) {
   const { gridContainerRef, activePresetIndex, setActivePresetIndex } =
     usePresetsKeyboardNav<HTMLUListElement>(colorTuples.length);
 
@@ -213,13 +57,16 @@ function ColorPresetList({ colorTuples, onHexPresetChange }: PresetsListProps) {
   );
 }
 
-export default function ColorPresets({ activeTab, onHexPresetChange }: Props) {
+export default function ColorPresets({
+  activeTab,
+  onHexPresetChange,
+}: ExternalProps) {
   const selectedList = colorPresets[activeTab];
 
   return (
     <Card title={`Presets (${activeTab})`} striped gapSize="small">
       {selectedList.length > 0 ? (
-        <ColorPresetList
+        <ColorPresetsCore
           key={activeTab}
           colorTuples={selectedList}
           onHexPresetChange={onHexPresetChange}

--- a/src/components/ColorMenus/ColorPresets.tsx
+++ b/src/components/ColorMenus/ColorPresets.tsx
@@ -1,0 +1,167 @@
+import {
+  ColorTuple,
+  HAIR_EYE_COLOR_PRESETS,
+  SKIN_COLOR_PRESETS,
+  MISC_COLOR_PRESETS,
+} from "@/typesConstants/colors";
+
+import Card from "../Card/";
+import ColorButton from "./ColorButton";
+import { UiTab } from "./localTypes";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ArrowKey, isArrowKey } from "@/utils/keyboard";
+import { clamp } from "@/utils/math";
+
+type Props = {
+  activeTab: UiTab;
+  onHexPresetChange: (hex1: string, hex2: string) => void;
+};
+
+function mapKeyToNewIndex(
+  colorCount: number,
+  gridCount: number,
+  arrowKey: ArrowKey
+): number {
+  return 0;
+}
+
+function usePresetsKeyboardNav<Element extends HTMLElement>(
+  numPresets: number
+) {
+  const [activePresetIndex, setActivePresetIndex] = useState(0);
+
+  // Pretty sure I can get away with just using a ref value for the column
+  // count, since the value will only ever be used within effects
+  const gridColumnCountRef = useRef(0);
+  const gridContainerRef = useRef<Element>(null);
+  const numPresetsRef = useRef(numPresets);
+
+  useEffect(() => {
+    numPresetsRef.current = numPresets;
+  }, [numPresets]);
+
+  // Effect for updating the number of columns as the element resizes
+  useEffect(() => {
+    const gridContainer = gridContainerRef.current;
+    if (gridContainer === null) return;
+
+    const updateColumnCountOnResize = () => {
+      const gridStyling = window.getComputedStyle(gridContainer);
+      const count = gridStyling
+        .getPropertyValue("grid-template-columns")
+        .split(" ").length;
+
+      gridColumnCountRef.current = count;
+    };
+
+    const observer = new ResizeObserver(updateColumnCountOnResize);
+    observer.observe(gridContainer);
+    return () => observer.disconnect();
+  }, []);
+
+  // Effect for listening to keyboard input; must run after column resize effect
+  useEffect(() => {
+    const gridContainer = gridContainerRef.current;
+    if (gridContainer === null) return;
+
+    const handleKeyInput = (event: KeyboardEvent) => {
+      const { key } = event;
+      if (!isArrowKey(key)) return;
+
+      event.preventDefault();
+      if (numPresetsRef.current === 0) {
+        return;
+      }
+
+      const newIndex = mapKeyToNewIndex(
+        numPresetsRef.current,
+        gridColumnCountRef.current,
+        key
+      );
+
+      setActivePresetIndex(newIndex);
+    };
+
+    gridContainer.addEventListener("keydown", handleKeyInput);
+    return () => gridContainer.removeEventListener("keydown", handleKeyInput);
+  }, []);
+
+  const safeSetActivePresetIndex = useCallback(
+    (newIndex: number) => {
+      setActivePresetIndex((current) => {
+        if (!Number.isInteger(newIndex) || newIndex < 0) return current;
+        return clamp(newIndex, 0, numPresets);
+      });
+    },
+    [numPresets]
+  );
+
+  return {
+    gridContainerRef,
+    activePresetIndex,
+    setActivePresetIndex: safeSetActivePresetIndex,
+  } as const;
+}
+
+const colorPresets = {
+  eyes: HAIR_EYE_COLOR_PRESETS,
+  hair: HAIR_EYE_COLOR_PRESETS,
+  skin: SKIN_COLOR_PRESETS,
+  misc: MISC_COLOR_PRESETS,
+} as const satisfies Record<UiTab, readonly ColorTuple[]>;
+
+type PresetsListProps = Omit<Props, "activeTab"> & {
+  colorTuples: readonly ColorTuple[];
+};
+
+/**
+ * @todo Make empty state for when colors aren't available
+ * @todo Extract out the arrow key logic into a separate utils file
+ * @todo Also need to figure out how tab indexing and keyboard navigation even
+ * work here.
+ */
+function ColorPresetList({ colorTuples, onHexPresetChange }: PresetsListProps) {
+  const { gridContainerRef, activePresetIndex, setActivePresetIndex } =
+    usePresetsKeyboardNav<HTMLUListElement>(colorTuples.length);
+
+  return (
+    <ul
+      ref={gridContainerRef}
+      className="mt-1 grid w-full max-w-[400px] grid-cols-3 justify-between gap-3"
+    >
+      {colorTuples.map(([hex1, hex2], index) => (
+        <li key={`${hex1}-${hex2}`} className="mx-auto block">
+          <ColorButton
+            primaryHex={hex1}
+            secondaryHex={hex2}
+            selected={index === activePresetIndex}
+            onClick={() => {
+              onHexPresetChange(hex1, hex2);
+              setActivePresetIndex(index);
+            }}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default function ColorPresets({ activeTab, onHexPresetChange }: Props) {
+  const selectedList = colorPresets[activeTab];
+
+  return (
+    <Card title={`Presets (${activeTab})`} striped gapSize="small">
+      {selectedList.length > 0 ? (
+        <ColorPresetList
+          key={activeTab}
+          colorTuples={selectedList}
+          onHexPresetChange={onHexPresetChange}
+        />
+      ) : (
+        <p className="mt-1 rounded-md bg-teal-950/60 px-2 py-3 text-center text-sm font-medium text-teal-100">
+          No color presets available.
+        </p>
+      )}
+    </Card>
+  );
+}

--- a/src/components/ColorMenus/ColorPresets.tsx
+++ b/src/components/ColorMenus/ColorPresets.tsx
@@ -27,8 +27,12 @@ const colorPresets = {
 } as const satisfies Record<UiTab, readonly ColorTuple[]>;
 
 function ColorPresetsCore({ colorTuples, onHexPresetChange }: CoreProps) {
-  const { gridContainerRef, activePresetIndex, setActivePresetIndex } =
-    usePresetsKeyboardNav<HTMLUListElement>(colorTuples.length);
+  const {
+    gridContainerRef,
+    activeButtonRef,
+    activePresetIndex,
+    setActivePresetIndex,
+  } = usePresetsKeyboardNav<HTMLUListElement>(colorTuples.length);
 
   return (
     <ul
@@ -41,6 +45,7 @@ function ColorPresetsCore({ colorTuples, onHexPresetChange }: CoreProps) {
         return (
           <li key={`${hex1}-${hex2}`} className="mx-auto block">
             <ColorButton
+              ref={selected ? activeButtonRef : undefined}
               primaryHex={hex1}
               secondaryHex={hex2}
               selected={selected}

--- a/src/components/ColorMenus/usePresetsKeyboardNav.ts
+++ b/src/components/ColorMenus/usePresetsKeyboardNav.ts
@@ -65,6 +65,7 @@ export default function usePresetsKeyboardNav<Element extends HTMLElement>(
   // count, since the value will only ever be used within effects
   const gridColumnCountRef = useRef(0);
   const gridContainerRef = useRef<Element>(null);
+  const activeButtonRef = useRef<HTMLButtonElement>(null);
   const updateInfoRef = useRef({ activePresetIndex, numPresets });
 
   // Effect for updating the number of columns as the element resizes
@@ -120,6 +121,15 @@ export default function usePresetsKeyboardNav<Element extends HTMLElement>(
     return () => gridContainer.removeEventListener("keydown", handleKeyInput);
   }, []);
 
+  useEffect(() => {
+    const gridContainer = gridContainerRef.current;
+    if (gridContainer === null) return;
+
+    if (gridContainer.contains(document.activeElement)) {
+      activeButtonRef.current?.focus();
+    }
+  }, [activePresetIndex]);
+
   /**
    * @todo Effect is only for debugging - delete once fully done (and tested!)
    */
@@ -147,7 +157,10 @@ export default function usePresetsKeyboardNav<Element extends HTMLElement>(
 
   return {
     gridContainerRef,
+    activeButtonRef,
     activePresetIndex,
+
+    // Not exposing the raw state dispatch because that spells trouble
     setActivePresetIndex: safeSetActivePresetIndex,
   } as const;
 }

--- a/src/components/ColorMenus/usePresetsKeyboardNav.ts
+++ b/src/components/ColorMenus/usePresetsKeyboardNav.ts
@@ -21,6 +21,8 @@ export function mapKeyToGridIndex(
    * @todo Still need to fix logic for ArrowUp/ArrowDown so that they can deal
    * with grids that have blanks
    */
+  // Have to do some funky logic for some branches to account for when the grid
+  // has blanks
   let offsetRowIndex = rowIndex;
   let offsetColIndex = colIndex;
   switch (arrowKey) {
@@ -30,17 +32,14 @@ export function mapKeyToGridIndex(
     }
 
     case "ArrowRight": {
-      if (rowIndex === lastRowIndex) {
-        const itemsOnLastRow = itemCount % gridCount || gridCount;
-        offsetColIndex = colIndex === itemsOnLastRow - 1 ? 0 : colIndex + 1;
-      } else {
-        offsetColIndex = colIndex === gridCount - 1 ? 0 : colIndex + 1;
-      }
-
+      const itemsOnLastRow = itemCount % gridCount || gridCount;
+      const base = rowIndex === lastRowIndex ? itemsOnLastRow : gridCount;
+      offsetColIndex = colIndex === base - 1 ? 0 : colIndex + 1;
       break;
     }
 
     case "ArrowUp": {
+      const itemsInColumn = null;
       offsetRowIndex = rowIndex === 0 ? lastRowIndex : rowIndex - 1;
       break;
     }
@@ -51,6 +50,7 @@ export function mapKeyToGridIndex(
     }
   }
 
+  // Just using Math.min as an extra precaution to prevent out-of-bounds errors
   const lastItemIndex = itemCount - 1;
   const computedIndex = lastColIndex * offsetRowIndex + offsetColIndex;
   return Math.min(computedIndex, lastItemIndex);
@@ -128,9 +128,8 @@ export default function usePresetsKeyboardNav<Element extends HTMLElement>(
     if (gridContainer === null) return;
 
     const intervalId = window.setInterval(() => {
-      gridContainer.dispatchEvent(
-        new KeyboardEvent("keydown", { key: "ArrowRight" })
-      );
+      const newEvent = new KeyboardEvent("keydown", { key: "ArrowUp" });
+      gridContainer.dispatchEvent(newEvent);
     }, 500);
 
     return () => window.clearInterval(intervalId);

--- a/src/components/ColorMenus/usePresetsKeyboardNav.ts
+++ b/src/components/ColorMenus/usePresetsKeyboardNav.ts
@@ -1,0 +1,154 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ArrowKey, isArrowKey } from "@/utils/keyboard";
+import { clamp } from "@/utils/math";
+
+export function mapKeyToGridIndex(
+  itemCount: number,
+  gridCount: number,
+  currentIndex: number,
+  arrowKey: ArrowKey
+): number {
+  if (itemCount === 0) {
+    return 0;
+  }
+
+  const rowIndex = Math.floor(currentIndex / gridCount);
+  const colIndex = currentIndex % gridCount;
+  const lastRowIndex = Math.floor(itemCount / gridCount);
+  const lastColIndex = Math.floor(itemCount / lastRowIndex);
+
+  /**
+   * @todo Still need to fix logic for ArrowUp/ArrowDown so that they can deal
+   * with grids that have blanks
+   */
+  let offsetRowIndex = rowIndex;
+  let offsetColIndex = colIndex;
+  switch (arrowKey) {
+    case "ArrowLeft": {
+      offsetColIndex = colIndex === 0 ? gridCount - 1 : colIndex - 1;
+      break;
+    }
+
+    case "ArrowRight": {
+      if (rowIndex === lastRowIndex) {
+        const itemsOnLastRow = itemCount % gridCount || gridCount;
+        offsetColIndex = colIndex === itemsOnLastRow - 1 ? 0 : colIndex + 1;
+      } else {
+        offsetColIndex = colIndex === gridCount - 1 ? 0 : colIndex + 1;
+      }
+
+      break;
+    }
+
+    case "ArrowUp": {
+      offsetRowIndex = rowIndex === 0 ? lastRowIndex : rowIndex - 1;
+      break;
+    }
+
+    case "ArrowDown": {
+      offsetRowIndex = rowIndex === lastRowIndex ? 0 : rowIndex + 1;
+      break;
+    }
+  }
+
+  const lastItemIndex = itemCount - 1;
+  const computedIndex = lastColIndex * offsetRowIndex + offsetColIndex;
+  return Math.min(computedIndex, lastItemIndex);
+}
+
+export default function usePresetsKeyboardNav<Element extends HTMLElement>(
+  numPresets: number
+) {
+  const [activePresetIndex, setActivePresetIndex] = useState(0);
+
+  // Pretty sure I can get away with just using a ref value for the column
+  // count, since the value will only ever be used within effects
+  const gridColumnCountRef = useRef(0);
+  const gridContainerRef = useRef<Element>(null);
+  const updateInfoRef = useRef({ activePresetIndex, numPresets });
+
+  // Effect for updating the number of columns as the element resizes
+  useEffect(() => {
+    const gridContainer = gridContainerRef.current;
+    if (gridContainer === null) return;
+
+    const updateColumnCountOnResize = () => {
+      const gridStyling = window.getComputedStyle(gridContainer);
+      const count = gridStyling
+        .getPropertyValue("grid-template-columns")
+        .split(" ").length;
+
+      gridColumnCountRef.current = count;
+    };
+
+    const observer = new ResizeObserver(updateColumnCountOnResize);
+    observer.observe(gridContainer);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    updateInfoRef.current = { activePresetIndex, numPresets };
+  }, [numPresets, activePresetIndex]);
+
+  // Effect for listening to keyboard input; must run after column resize effect
+  useEffect(() => {
+    const gridContainer = gridContainerRef.current;
+    if (gridContainer === null) return;
+
+    const handleKeyInput = (event: KeyboardEvent) => {
+      const { key } = event;
+      if (!isArrowKey(key)) return;
+
+      event.preventDefault();
+      const { activePresetIndex, numPresets } = updateInfoRef.current;
+
+      if (numPresets === 0) {
+        return;
+      }
+
+      const newIndex = mapKeyToGridIndex(
+        numPresets,
+        gridColumnCountRef.current,
+        activePresetIndex,
+        key
+      );
+
+      setActivePresetIndex(newIndex);
+    };
+
+    gridContainer.addEventListener("keydown", handleKeyInput);
+    return () => gridContainer.removeEventListener("keydown", handleKeyInput);
+  }, []);
+
+  /**
+   * @todo Effect is only for debugging - delete once fully done (and tested!)
+   */
+  useEffect(() => {
+    const gridContainer = gridContainerRef.current;
+    if (gridContainer === null) return;
+
+    const intervalId = window.setInterval(() => {
+      gridContainer.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowRight" })
+      );
+    }, 500);
+
+    return () => window.clearInterval(intervalId);
+  }, []);
+
+  const safeSetActivePresetIndex = useCallback(
+    (newIndex: number) => {
+      setActivePresetIndex((current) => {
+        if (!Number.isInteger(newIndex) || newIndex < 0) return current;
+        return clamp(newIndex, 0, numPresets - 1);
+      });
+    },
+    [numPresets]
+  );
+
+  return {
+    gridContainerRef,
+    activePresetIndex,
+    setActivePresetIndex: safeSetActivePresetIndex,
+  } as const;
+}

--- a/src/components/ColorMenus/usePresetsKeyboardNav.ts
+++ b/src/components/ColorMenus/usePresetsKeyboardNav.ts
@@ -50,10 +50,9 @@ export function mapKeyToGridIndex(
     }
   }
 
-  // Just using Math.min as an extra precaution to prevent out-of-bounds errors
   const lastItemIndex = itemCount - 1;
   const computedIndex = lastColIndex * offsetRowIndex + offsetColIndex;
-  return Math.min(computedIndex, lastItemIndex);
+  return clamp(computedIndex, 0, lastItemIndex);
 }
 
 export default function usePresetsKeyboardNav<Element extends HTMLElement>(

--- a/src/components/ColorPicker/useSlider.ts
+++ b/src/components/ColorPicker/useSlider.ts
@@ -1,4 +1,5 @@
 import { useEffect, useLayoutEffect, useRef } from "react";
+import { ArrowKey, isArrowKey } from "@/utils/keyboard";
 
 import useSquareDimensions from "./useSquareDimensions";
 import { wrapHue } from "./colorHelpers";
@@ -11,14 +12,7 @@ const cardinalDirections = {
   ArrowUp: 90,
   ArrowLeft: 180,
   ArrowDown: 270,
-} as const satisfies Record<string, number>;
-
-function isArrowKey(value: unknown): value is keyof typeof cardinalDirections {
-  return (
-    typeof value === "string" &&
-    (value as keyof typeof cardinalDirections) in cardinalDirections
-  );
-}
+} as const satisfies Record<ArrowKey, number>;
 
 export default function useSlider(
   hue: number,

--- a/src/utils/keyboard.ts
+++ b/src/utils/keyboard.ts
@@ -1,0 +1,16 @@
+/**
+ * @file Collection of functions and types for making it easier to deal with
+ * keyboard input.
+ */
+
+export const arrowKeys = [
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowUp",
+  "ArrowDown",
+] as const;
+export type ArrowKey = (typeof arrowKeys)[number];
+
+export function isArrowKey(value: unknown): value is ArrowKey {
+  return typeof value === "string" && arrowKeys.includes(value as ArrowKey);
+}


### PR DESCRIPTION
This updates adds functionality for making the presets menu much more keyboard-accessible, by letting you navigate the list entirely through the arrow keys.

Two notes:
- This logic may need to end up being applied to the color buttons for the swatches (just in a more limited capacity)
- The navigation for the logic for the presets does support wrapping around to the other side of the grid. Need to go back to the keyboard nav for the characters list and patch that in